### PR TITLE
"Death to the text_node and replace it with content to make it consisten...

### DIFF
--- a/lib/happymapper.rb
+++ b/lib/happymapper.rb
@@ -124,7 +124,7 @@ module HappyMapper
     #     the object will be converted upon parsing
     # @param [Hash] options additional parameters to send to the relationship
     #
-    def content(name, type, options={})
+    def content(name, type=String, options={})
       @content = TextNode.new(name, type, options)
       attr_accessor @content.method_name.intern
     end


### PR DESCRIPTION
...t with happymapper'.

On this fix, again there is little bit incosistency (it needs one extra parameter to be passed).... 

The nokogiri-happymapper content method is like 

`content 'status', String`  while for happymapper its just `content 'status'` takes String as default type.

can we give some default tag type here ... String ?
