### PR TITLE
add in-place parsing on an instance: instance.parse()

### DIFF
--- a/lib/happymapper.rb
+++ b/lib/happymapper.rb
@@ -309,8 +309,12 @@ module HappyMapper
       
       nodes.each_slice(limit) do |slice|
         
-        part = slice.map do |n|
-          obj = new
+        part = slice.map do |n|  
+          
+          # If an existing HappyMapper object is provided, update it with the
+          # values from the xml being parsed.  Otherwise, create a new object
+          
+          obj = options[:update] ? options[:update] : new
 
           attributes.each do |attr|
             obj.send("#{attr.method_name}=",attr.from_xml_node(n, namespace, namespaces))
@@ -612,7 +616,15 @@ module HappyMapper
     write_out_to_xml ? builder.to_xml : builder
     
   end
-  
+     
+  # Parse the xml and update this instance. This does not update instances
+  # of HappyMappers that are children of this object.  New instances will be
+  # created for any HappyMapper children of this object.       
+  #  
+  # Params and return are the same as the class parse() method above.
+  def parse(xml, options = {})
+    self.class.parse(xml, options.merge!(:update => self))
+  end
   
 end
 

--- a/spec/parse_instance_spec.rb
+++ b/spec/parse_instance_spec.rb
@@ -1,0 +1,129 @@
+require File.dirname(__FILE__) + '/spec_helper.rb'
+
+parse_instance_initial_xml = %{
+  <root attr1="initial">
+    <item attr1="initial">
+      <description>initial</description>
+      <subitem attr1="initial">
+        <name>initial</name>
+      </subitem>
+      <subitem attr1="initial">
+        <name>initial</name>
+      </subitem>
+    </item>
+    <item attr1="initial">
+      <description>initial</description>
+      <subitem attr1="initial">
+        <name>initial</name>
+      </subitem>
+      <subitem attr1="initial">
+        <name>initial</name>
+      </subitem>
+    </item>
+  </root>
+}
+
+parse_instance_updated_xml = %{
+  <root attr1="updated">
+    <item attr1="updated">
+      <description>updated</description>
+      <subitem attr1="updated">
+        <name>updated</name>
+      </subitem>
+      <subitem attr1="updated">
+        <name>updated</name>
+      </subitem>
+    </item>
+    <item attr1="updated">
+      <description>updated</description>
+      <subitem attr1="updated">
+        <name>updated</name>
+      </subitem>
+      <subitem attr1="updated">
+        <name>updated</name>
+      </subitem>
+    </item>
+  </root>
+}
+
+module ParseInstanceSpec
+  class SubItem
+    include HappyMapper
+    tag 'subitem'
+    attribute :attr1, String
+    element :name, String
+  end
+  class Item
+    include HappyMapper
+    tag 'item'
+    attribute :attr1, String
+    element :description, String
+    has_many :sub_items, SubItem
+  end
+  class Root
+    include HappyMapper
+    tag 'root'
+    attribute :attr1, String
+    has_many :items, Item
+  end
+end
+
+describe HappyMapper do
+  describe "update existing instance by parsing new xml" do
+    
+    it 'should have initial values' do
+      @initial.attr1.should == 'initial'
+      @initial.items[0].attr1.should == 'initial'
+      @initial.items[0].description.should == 'initial'
+      @initial.items[0].sub_items[0].attr1.should == 'initial'
+      @initial.items[0].sub_items[0].name.should == 'initial'
+      @initial.items[0].sub_items[1].attr1.should == 'initial'
+      @initial.items[0].sub_items[1].name.should == 'initial'
+      @initial.items[1].attr1.should == 'initial'
+      @initial.items[1].description.should == 'initial'
+      @initial.items[1].sub_items[0].attr1.should == 'initial'
+      @initial.items[1].sub_items[0].name.should == 'initial'
+      @initial.items[1].sub_items[1].attr1.should == 'initial'
+      @initial.items[1].sub_items[1].name.should == 'initial'
+    end
+    
+    it 'should have updated values' do
+      ParseInstanceSpec::Root.parse(parse_instance_updated_xml, :update => @initial)
+      @initial.attr1.should == 'updated'
+      @initial.items[0].attr1.should == 'updated'
+      @initial.items[0].description.should == 'updated'
+      @initial.items[0].sub_items[0].attr1.should == 'updated'
+      @initial.items[0].sub_items[0].name.should == 'updated'
+      @initial.items[0].sub_items[1].attr1.should == 'updated'
+      @initial.items[0].sub_items[1].name.should == 'updated'
+      @initial.items[1].attr1.should == 'updated'
+      @initial.items[1].description.should == 'updated'
+      @initial.items[1].sub_items[0].attr1.should == 'updated'
+      @initial.items[1].sub_items[0].name.should == 'updated'
+      @initial.items[1].sub_items[1].attr1.should == 'updated'
+      @initial.items[1].sub_items[1].name.should == 'updated'
+    end
+    
+    it "should be able to update instance from 'parse()' instance method" do 
+      @initial.parse(parse_instance_updated_xml)
+      @initial.attr1.should == 'updated'
+      @initial.items[0].attr1.should == 'updated'
+      @initial.items[0].description.should == 'updated'
+      @initial.items[0].sub_items[0].attr1.should == 'updated'
+      @initial.items[0].sub_items[0].name.should == 'updated'
+      @initial.items[0].sub_items[1].attr1.should == 'updated'
+      @initial.items[0].sub_items[1].name.should == 'updated'
+      @initial.items[1].attr1.should == 'updated'
+      @initial.items[1].description.should == 'updated'
+      @initial.items[1].sub_items[0].attr1.should == 'updated'
+      @initial.items[1].sub_items[0].name.should == 'updated'
+      @initial.items[1].sub_items[1].attr1.should == 'updated'
+      @initial.items[1].sub_items[1].name.should == 'updated'
+    end
+    
+    before(:each) do
+      @initial = ParseInstanceSpec::Root.parse(parse_instance_initial_xml)
+    end
+  end
+end
+


### PR DESCRIPTION
Usage:

instance = SomeHappyMapper.parse(old_xml)

new_xml = Service.get_xml

instance.parse(new_xml)
## 

Allows for maintaining internal state of an instance by not being forced to create a new instance.
