### PR TITLE
Reusable base class

### DIFF
--- a/lib/happymapper.rb
+++ b/lib/happymapper.rb
@@ -580,7 +580,7 @@ module HappyMapper
               # process should have their contents retrieved and attached
               # to the builder structure
               #
-              item.to_xml(xml,element.options[:namespace],element.tag || nil)
+              item.to_xml(xml,element.options[:namespace],element.options[:tag] || nil)
 
             elsif item
             

--- a/spec/happymapper_generic_base_spec.rb
+++ b/spec/happymapper_generic_base_spec.rb
@@ -21,6 +21,11 @@ module GenericBase
     attribute :href, String
     attribute :other, String
   end
+  class Sub
+    include HappyMapper
+    tag 'subelement'
+    has_one :jello, Base, :tag => 'jello'
+  end
   class Root
     include HappyMapper     
     tag 'root'
@@ -28,6 +33,7 @@ module GenericBase
     has_many :blargs, Base, :tag => 'blarg', :xpath => '.'
     has_many :jellos, Base, :tag => 'jello', :xpath => '.'
     has_many :subjellos, Base, :tag => 'jello', :xpath => 'subelement/.', :read_only => true
+    has_one :sub_element, Sub
   end
 end
 
@@ -36,7 +42,8 @@ describe HappyMapper do
   describe "can have generic classes using tag '*'" do
       
     before(:all) do
-      @root = GenericBase::Root.parse(generic_class_xml)  
+      @root = GenericBase::Root.parse(generic_class_xml)
+      @xml = Nokogiri::XML(@root.to_xml)   
     end
     
     it 'should map different elements to same class' do
@@ -65,18 +72,21 @@ describe HappyMapper do
       @root.subjellos[0].other.should == 'othertext'
     end
 
-    it 'should #to_xml using parent element tag name' do
-      xml = Nokogiri::XML(@root.to_xml)
-      xml.xpath('/root/description').text.should == 'some description'
-      xml.xpath('/root/blarg[1]/@name').text.should == 'blargname1'
-      xml.xpath('/root/blarg[1]/@href').text.should == 'http://blarg.com'
-      xml.xpath('/root/blarg[1]/@other').text.should be_empty
-      xml.xpath('/root/blarg[2]/@name').text.should == 'blargname2'
-      xml.xpath('/root/blarg[2]/@href').text.should == 'http://blarg.com'
-      xml.xpath('/root/blarg[2]/@other').text.should be_empty
-      xml.xpath('/root/jello[1]/@name').text.should == 'jelloname'
-      xml.xpath('/root/jello[1]/@href').text.should == 'http://jello.com'
-      xml.xpath('/root/jello[1]/@other').text.should be_empty  
+    it 'should #to_xml using parent element tag name' do      
+      @xml.xpath('/root/description').text.should == 'some description'
+      @xml.xpath('/root/blarg[1]/@name').text.should == 'blargname1'
+      @xml.xpath('/root/blarg[1]/@href').text.should == 'http://blarg.com'
+      @xml.xpath('/root/blarg[1]/@other').text.should be_empty
+      @xml.xpath('/root/blarg[2]/@name').text.should == 'blargname2'
+      @xml.xpath('/root/blarg[2]/@href').text.should == 'http://blarg.com'
+      @xml.xpath('/root/blarg[2]/@other').text.should be_empty
+      @xml.xpath('/root/jello[1]/@name').text.should == 'jelloname'
+      @xml.xpath('/root/jello[1]/@href').text.should == 'http://jello.com'
+      @xml.xpath('/root/jello[1]/@other').text.should be_empty  
+    end
+    
+    it "should properly respect child HappyMapper tags if tag isn't provided on the element defintion" do
+      @xml.xpath('root/subelement').should have(1).item
     end
   end                   
 end


### PR DESCRIPTION
Can create reusable base classes.   Below sandwich and burger are basically the same, so use a base class for them in a larger doc.  The key is the tags.  The base item has a tag of '*'.  The parent doc chooses the tag to use when parsing and when printing to xml.

``` xml
<lunch>
  <burger container='bun' filler='beef patty'/>
  <sandwich container='rye' filler='turkey'/>
  <sandwich container='wheat' filler='salami/'>
</lunch>
```

``` ruby
class StackedFoodItem
  include HappyMapper
  tag '*'
  attribute :container, String
  attribute :filler, String
end

class Lunch
  include HappyMapper
  tag 'lunch'
  has_one :burger, StackedFoodItem, :tag => 'burger'
  has_many :sandwiches, StackedFoodItem, :tag => 'sandwich'
end

lunch = Lunch.parse(xml)
lunch.burger.filler += ' and mustard'
lunch.sandwiches[0].filler += ' and ham'
```
