### PR TITLE
Add callback for setting Nokogiri ParseOptions

### DIFF
--- a/lib/happymapper.rb
+++ b/lib/happymapper.rb
@@ -231,6 +231,23 @@ module HappyMapper
 
       has_one name, wrapper
     end
+    
+    # The callback defined through {.on_config}.
+    # 
+    # @return [Proc] the proc to pass to Nokogiri to setup parse options. nil if empty.
+    #
+    def config_callback
+      @config_callback
+    end
+    
+    # Register a config callback according to the block Nokogori expects when calling Nokogiri::XML::Document.parse().
+    # See http://nokogiri.org/Nokogiri/XML/Document.html#method-c-parse
+    #
+    # @param [Proc] the proc to pass to Nokogiri to setup parse options
+    #
+    def on_config(&blk)
+      @config_callback = blk
+    end
 
     #
     # @param [Nokogiri::XML::Node,Nokogiri:XML::Document,String] xml the XML 
@@ -258,7 +275,7 @@ module HappyMapper
           # Attempt to parse the xml value with Nokogiri XML as a document
           # and select the root element
           
-          xml = Nokogiri::XML(xml, nil, nil, Nokogiri::XML::ParseOptions::STRICT)
+          xml = Nokogiri::XML(xml, nil, nil, Nokogiri::XML::ParseOptions::STRICT, &config_callback)
           node = xml.root
         end
 

--- a/spec/fixtures/set_config_options.xml
+++ b/spec/fixtures/set_config_options.xml
@@ -1,0 +1,3 @@
+<root>
+	<item>&#26;some item</item>
+</root>

--- a/spec/happymapper_spec.rb
+++ b/spec/happymapper_spec.rb
@@ -1063,4 +1063,43 @@ describe HappyMapper do
      end
    end
   
+  context "when letting user set Nokogiri::XML::ParseOptions" do
+    let(:default) {
+      Class.new do
+        include HappyMapper
+        element :item, String
+      end
+    }
+    let(:custom) {
+      Class.new do
+        include HappyMapper
+        element :item, String
+        on_config do |config|
+          config.default_xml
+        end
+      end     
+    }
+    
+    it 'initializes @config_callback to nil' do
+      default.config_callback.should be_nil
+    end
+    
+    it 'defaults to Nokogiri::XML::ParseOptions::STRICT' do
+     expect { default.parse(fixture_file('set_config_options.xml')) }.to raise_error(Nokogiri::XML::SyntaxError)
+    end
+    
+    it 'accepts .on_config callback' do
+      custom.config_callback.should_not be_nil
+    end
+    
+    it 'parses according to @config_callback' do
+      expect { custom.parse(fixture_file('set_config_options.xml')) }.to_not raise_error(Nokogiri::XML::SyntaxError)
+    end
+    
+    it 'can clear @config_callback' do
+      custom.on_config {}
+      expect { custom.parse(fixture_file('set_config_options.xml')) }.to raise_error(Nokogiri::XML::SyntaxError)
+    end    
+  end
+  
 end


### PR DESCRIPTION
From Issue dam5s/happymapper#18

Allows us to register a callback to send to Nokogiri::XML() so we can modify ParseOptions.  The callback is defined by [Nokogori](http://nokogiri.org/Nokogiri/XML/Document.html#method-c-parse)

``` ruby
class Foo
  include HappyMapper
  has_one :bar, String

  on_config do |config|
    config.nonet
  end
end
```
