### PR TITLE
Support for default attribute values

### DIFF
--- a/lib/happymapper.rb
+++ b/lib/happymapper.rb
@@ -370,7 +370,9 @@ module HappyMapper
           obj = options[:update] ? options[:update] : new
 
           attributes.each do |attr|
-            obj.send("#{attr.method_name}=",attr.from_xml_node(n, namespace, namespaces))
+            value = attr.from_xml_node(n, namespace, namespaces)
+            value = attr.default if value.nil?
+            obj.send("#{attr.method_name}=", value)
           end
 
           elements.each do |elem|
@@ -429,7 +431,14 @@ module HappyMapper
         collection
       end
     end
+  end
 
+  # Set all attributes with a default to their default values
+  def initialize
+    super
+    self.class.attributes.reject {|attr| attr.default.nil?}.each do |attr|
+      send("#{attr.method_name}=", attr.default)
+    end
   end
 
   #
@@ -479,6 +488,7 @@ module HappyMapper
       unless attribute.options[:read_only]
 
         value = send(attribute.method_name)
+        value = nil if value == attribute.default
 
         #
         # If the attribute defines an on_save lambda/proc or value that maps to

--- a/lib/happymapper/attribute.rb
+++ b/lib/happymapper/attribute.rb
@@ -1,3 +1,13 @@
 module HappyMapper
-  class Attribute < Item; end
+  class Attribute < Item
+    attr_accessor :default
+
+    # @see Item#initialize
+    # Additional options:
+    #   :default => Object The default value for this
+    def initialize(name, type, o={})
+      super
+      self.default = o[:default]
+    end
+  end
 end

--- a/spec/default_option_spec.rb
+++ b/spec/default_option_spec.rb
@@ -1,0 +1,32 @@
+require 'spec/spec_helper'
+
+describe "The default option of attributes" do
+
+  class WithDefault
+    include HappyMapper
+    tag 'foo'
+    attribute :bar, String, :default => 'baz'
+  end
+
+  it 'should return the default value after parsing a string without it' do
+    foo = WithDefault.parse('<foo />')
+    foo.bar.should == 'baz'
+  end
+
+  it 'should not include the default value in the produced xml' do
+    foo = WithDefault.new
+    foo.to_xml.should == %{<?xml version="1.0"?>\n<foo/>\n}
+  end
+
+  it 'should not return the default value when a non-nil value has been set' do
+    foo = WithDefault.parse('<foo />')
+    foo.bar = 'not-baz'
+    foo.bar.should_not == 'baz'
+  end
+
+  it 'should include a non-nil value in the XML' do
+    foo = WithDefault.new
+    foo.bar = 'not-baz'
+    foo.to_xml.should == %{<?xml version="1.0"?>\n<foo bar="not-baz"/>\n}
+  end
+end

--- a/spec/happymapper_attribute_spec.rb
+++ b/spec/happymapper_attribute_spec.rb
@@ -17,5 +17,10 @@ describe HappyMapper::Attribute do
     it 'should know that it is NOT a text node' do
       @attr.text_node?.should be_false
     end
+
+    it 'should accept :default as an option' do
+      attr = described_class.new(:foo, String, :default => 'foobar')
+      attr.default.should == 'foobar'
+    end
   end
 end


### PR DESCRIPTION
(Sorry, I messed up https://github.com/dam5s/happymapper/pull/24 by pushing additional commits to this branch, which should be considered separately for inclusion. I force-pushed to remove them, but for some reason the commit in that pull request was also removed)

I've added support for a :default option to attribute declarations. This makes it easy to declare default values, without requiring you to write initialize functions that set them. When working with an XML schema, these :default values can nicely reflect the 'default' declarations in the XSD.

Our use case is we generate classes that include HappyMapper from information parsed from an XSD. With this extension we can easily add a :default => 'some_value' to the generated attribute :foo, String lines, based on the default declarations parsed from the XSD. However, it seems like something that may more generally be considered useful.
