### PR TITLE
Enable inheritance from HappyMapper classes

### DIFF
--- a/lib/happymapper.rb
+++ b/lib/happymapper.rb
@@ -10,10 +10,23 @@ module HappyMapper
   DEFAULT_NS = "happymapper"
 
   def self.included(base)
-    base.instance_variable_set("@attributes", [])
-    base.instance_variable_set("@elements", [])
-    base.instance_variable_set("@registered_namespaces", {})
-    base.instance_variable_set("@wrapper_anonymous_classes", {})
+    if !(base.superclass <= HappyMapper)
+      base.instance_eval do
+        @attributes = []
+        @elements = []
+        @registered_namespaces = {}
+        @wrapper_anonymous_classes = {}
+      end
+    else
+      base.instance_eval do
+        @attributes = superclass.attributes.dup
+        @elements = superclass.elements.dup
+        @registered_namespaces = 
+            superclass.instance_variable_get(:@registered_namespaces).dup
+        @wrapper_anonymous_classes = 
+            superclass.instance_variable_get(:@wrapper_anonymous_classes).dup
+      end
+    end
 
     base.extend ClassMethods
   end

--- a/spec/inheritance_spec.rb
+++ b/spec/inheritance_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe "inheritance of elements, attributes, etc. of HappyMapper classes" do
+
+  class Elem
+    include HappyMapper
+  end
+
+  class Parent
+    include HappyMapper
+    attribute :foo, String
+    element :bar, Elem
+  end
+
+  class Child < Parent
+    include HappyMapper
+    attribute :quux, String
+  end
+
+  describe 'should behave as a Parent with an additional attribute quux' do
+    it 'should be possible to serialize an instance of the Child class' do
+      child = Child.new
+      child.foo = 'something'
+      child.quux = 'something_else'
+      child.bar = Elem.new
+      # A bit convoluted, because attribute order is not guaranteed in 1.8.7
+      xml = child.to_xml
+      xml.should include '<?xml version="1.0"?>'
+      xml.should include 'quux="something_else"'
+      xml.should include 'foo="something"'
+      xml.should include "<elem\/>\n<\/child>\n"
+    end
+
+    it 'should be possible to deserialize XML into a Child class instance' do
+      xml = '<child foo="something" quux="something_else"><elem/></child>'
+      child = Child.parse(xml)
+      child.foo.should == 'something'
+      child.quux.should == 'something_else'
+      child.bar.should be_a Elem
+    end
+  end
+end


### PR DESCRIPTION
This is convenient if an XSD contains inheritance relationships. Can
also be used for multiple (top-level) elements that share the same type.
The subclass will inherit all attributes, elements, etc. from the
superclass and can add to them, independent of the superclass.
