### PR TITLE
Puts top level Boolean class in module HappyMapper

### DIFF
--- a/lib/happymapper.rb
+++ b/lib/happymapper.rb
@@ -20,9 +20,9 @@ module HappyMapper
       base.instance_eval do
         @attributes = superclass.attributes.dup
         @elements = superclass.elements.dup
-        @registered_namespaces = 
+        @registered_namespaces =
             superclass.instance_variable_get(:@registered_namespaces).dup
-        @wrapper_anonymous_classes = 
+        @wrapper_anonymous_classes =
             superclass.instance_variable_get(:@wrapper_anonymous_classes).dup
       end
     end

--- a/spec/happymapper_item_spec.rb
+++ b/spec/happymapper_item_spec.rb
@@ -33,18 +33,18 @@ describe HappyMapper::Item do
       item = HappyMapper::Item.new(:foo, String)
       item.constant.should == String
     end
-    
+
     it "should convert string type to constant" do
       item = HappyMapper::Item.new(:foo, 'String')
       item.constant.should == String
     end
-    
+
     it "should convert string with :: to constant" do
       item = HappyMapper::Item.new(:foo, 'Foo::Bar')
       item.constant.should == Foo::Bar
     end
   end
-  
+
   describe "#method_name" do
     it "should convert dashes to underscores" do
       item = HappyMapper::Item.new(:'foo-bar', String, :tag => 'foobar')


### PR DESCRIPTION
Putting classes in the top level namespace leads to havoc in the case when other libraries/gems use a Boolean class (for example [virtus](https://github.com/solnic/virtus)).

The seemingly strange `HappyMapper::Boolean` in the spec is not so odd really. The main thing is that all the references to Boolean in `happymapper_spec.rb` work.
