### PR TITLE
'Embedded' attributes break parsing when parent element is not present

### DIFF
--- a/lib/happymapper/element.rb
+++ b/lib/happymapper/element.rb
@@ -35,6 +35,8 @@ module HappyMapper
       if options[:attributes].is_a?(Hash)
         result = result.first unless result.respond_to?(:attribute_nodes)
 
+        return unless result.respond_to?(:attribute_nodes)
+
         result.attribute_nodes.each do |xml_attribute|
           if attribute_options = options[:attributes][xml_attribute.name.to_sym]
             attribute_value = Attribute.new(xml_attribute.name.to_sym, *attribute_options).from_xml_node(result, namespace, xpath_options)

--- a/spec/fixtures/current_weather_missing_elements.xml
+++ b/spec/fixtures/current_weather_missing_elements.xml
@@ -1,0 +1,18 @@
+<aws:weather xmlns:aws="http://www.aws.com/aws">
+  <aws:api version="2.0"/>
+  <aws:WebURL>http://weather.weatherbug.com/IN/Carmel-weather.html?ZCode=Z5546&amp;Units=0&amp;stat=MOCAR</aws:WebURL>
+  <aws:ob>
+    <aws:ob-date>
+      <aws:year number="2008"/>
+      <aws:month number="12" text="December" abbrv="Dec"/>
+      <aws:day number="30" text="Tuesday" abbrv="Tue"/>
+      <aws:hour number="4" hour-24="16"/>
+      <aws:minute number="18"/>
+      <aws:second number="01"/>
+      <aws:am-pm abbrv="PM"/>
+      <aws:time-zone offset="-5" text="Eastern Standard Time" abbrv="EST"/>
+    </aws:ob-date>
+    <aws:feels-like units="&amp;deg;F">51</aws:feels-like>
+    <aws:temp units="&amp;deg;F">51.8</aws:temp>
+  </aws:ob>
+</aws:weather>

--- a/spec/happymapper_spec.rb
+++ b/spec/happymapper_spec.rb
@@ -780,6 +780,10 @@ describe HappyMapper do
     feed.link.last.href.should == 'http://www.example.com/tv_shows.atom'
   end
 
+  it "parses xml with optional elements with embedded attributes" do
+    expect { CurrentWeather.parse(fixture_file('current_weather_missing_elements.xml')) }.to_not raise_error()
+  end
+
   it "returns nil rather than empty array for absent values when :single => true" do
     address = Address.parse('<?xml version="1.0" encoding="UTF-8"?><foo/>', :single => true)
     address.should be_nil


### PR DESCRIPTION
``` ruby
#!/usr/bin/env ruby

require 'rubygems'
require 'happymapper' # assuming you only have nokogiri-happymapper installed

xml = <<EOXML
<?xml version='1.0' encoding='UTF-8'?>
<foo>
  <boo />
</foo>
EOXML

class Foo
  include HappyMapper

  tag 'foo'
  element :moo, String, :attributes => { :guh => String }, :single => true
end

parsed = Foo.parse(xml, :single => true)
```

results in the following (shortened paths for easier reading):

```
/home/ggiesemann/2.0.0-p247/gems/nokogiri-happymapper-0.5.7/lib/happymapper/element.rb:38:in `handle_attributes_option': undefined method `attribute_nodes' for nil:NilClass (NoMethodError)
    from /home/ggiesemann/2.0.0-p247/gems/nokogiri-happymapper-0.5.7/lib/happymapper/element.rb:21:in `find'
    from /home/ggiesemann/2.0.0-p247/gems/nokogiri-happymapper-0.5.7/lib/happymapper/item.rb:36:in `from_xml_node'
    from /home/ggiesemann/2.0.0-p247/gems/nokogiri-happymapper-0.5.7/lib/happymapper.rb:390:in `block (3 levels) in parse'
    from /home/ggiesemann/2.0.0-p247/gems/nokogiri-happymapper-0.5.7/lib/happymapper.rb:389:in `each'
    from /home/ggiesemann/2.0.0-p247/gems/nokogiri-happymapper-0.5.7/lib/happymapper.rb:389:in `block (2 levels) in parse'
    from /home/ggiesemann/2.0.0-p247/gems/nokogiri-happymapper-0.5.7/lib/happymapper.rb:376:in `map'
    from /home/ggiesemann/2.0.0-p247/gems/nokogiri-happymapper-0.5.7/lib/happymapper.rb:376:in `block in parse'
    from /home/ggiesemann/2.0.0-p247/gems/nokogiri-1.6.0/lib/nokogiri/xml/node_set.rb:237:in `block in each'
    from /home/ggiesemann/2.0.0-p247/gems/nokogiri-1.6.0/lib/nokogiri/xml/node_set.rb:236:in `upto'
    from /home/ggiesemann/2.0.0-p247/gems/nokogiri-1.6.0/lib/nokogiri/xml/node_set.rb:236:in `each'
    from /home/ggiesemann/2.0.0-p247/gems/nokogiri-happymapper-0.5.7/lib/happymapper.rb:374:in `each_slice'
    from /home/ggiesemann/2.0.0-p247/gems/nokogiri-happymapper-0.5.7/lib/happymapper.rb:374:in `parse'
```

We parse XML with a lot of optional elements, and I was looking at switching over from happymapper which is how I discovered this bug.
