### PR TITLE
overwrite attributes and elements when inherited

### DIFF
--- a/lib/happymapper.rb
+++ b/lib/happymapper.rb
@@ -14,15 +14,17 @@ module HappyMapper
   def self.included(base)
     if !(base.superclass <= HappyMapper)
       base.instance_eval do
-        @attributes = []
-        @elements = []
+        @attributes = {}
+        @elements = {}
         @registered_namespaces = {}
         @wrapper_anonymous_classes = {}
       end
     else
       base.instance_eval do
-        @attributes = superclass.attributes.dup
-        @elements = superclass.elements.dup
+        @attributes =
+            superclass.instance_variable_get(:@attributes).dup
+        @elements =
+            superclass.instance_variable_get(:@elements).dup
         @registered_namespaces =
             superclass.instance_variable_get(:@registered_namespaces).dup
         @wrapper_anonymous_classes =
@@ -52,7 +54,7 @@ module HappyMapper
     #
     def attribute(name, type, options={})
       attribute = Attribute.new(name, type, options)
-      @attributes << attribute
+      @attributes[name] = attribute
       attr_accessor attribute.method_name.intern
     end
 
@@ -63,7 +65,7 @@ module HappyMapper
     #     an empty array is returned when there have been no attributes defined.
     #
     def attributes
-      @attributes
+      @attributes.values
     end
 
     #
@@ -107,7 +109,7 @@ module HappyMapper
     #
     def element(name, type, options={})
       element = Element.new(name, type, options)
-      @elements << element
+      @elements[name] = element
       attr_accessor element.method_name.intern
     end
 
@@ -119,7 +121,7 @@ module HappyMapper
     #     defined.
     #
     def elements
-      @elements
+      @elements.values
     end
 
     #

--- a/spec/inheritance_spec.rb
+++ b/spec/inheritance_spec.rb
@@ -19,6 +19,52 @@ describe "Using inheritance to share elements and attributes" do
     has_many :immunities, String
   end
 
+  class Overwrite < Parent
+    include HappyMapper
+
+    attribute :love, String
+    element :genetics, Integer
+  end
+
+  describe "Overwrite" do
+    let(:subject) do
+      xml = '<overwrite love="love" naivety="trusting"><genetics>1001</genetics><immunities>Chicken Pox</immunities></overwrite>'
+      Overwrite.parse(xml, single: true)
+    end
+
+    it 'overrides the parent elements and attributes' do
+      expect(Overwrite.attributes.count).to be == Parent.attributes.count
+      expect(Overwrite.elements.count).to be == Parent.elements.count
+    end
+
+    context "when parsing xml" do
+      it 'parses the new overwritten attribut' do
+        expect(subject.love).to be == "love"
+      end
+
+      it 'parses the new overwritten element' do
+        expect(subject.genetics).to be == 1001
+      end
+    end
+
+    context "when saving to xml" do
+      subject do
+        overwrite = Overwrite.new
+        overwrite.genetics = 1
+        overwrite.love = "love"
+        Nokogiri::XML(overwrite.to_xml).root
+      end
+
+      it 'has only 1 genetics element' do
+        expect(subject.xpath('//genetics').count).to be == 1
+      end
+
+      it 'has only 1 love attribute' do
+        expect(subject.xpath('@love').text).to be == "love"
+      end
+    end
+  end
+
   describe "Child", "a subclass of the Parent" do
     let(:subject) do
       xml = '<child love="99" naivety="trusting"><genetics>ABBA</genetics><immunities>Chicken Pox</immunities></child>'


### PR DESCRIPTION
When you inherit from a parent class and you want to overwrite an element, the element is added twice in the xml.

I've changed attributes and elements to hashes to allow overwrites. This can be considered a breaking change (even though no specs were changed or failed), so an update of the changelog is probably required and the version will probably be a minor.
