### PR TITLE
Correctly output boolean element value 'false'

### DIFF
--- a/lib/happymapper.rb
+++ b/lib/happymapper.rb
@@ -676,7 +676,7 @@ module HappyMapper
               #
               item.to_xml(xml,element.options[:namespace],element.options[:tag] || nil)
 
-            elsif item
+            elsif !item.nil?
 
               item_namespace = element.options[:namespace] || self.class.namespace || default_namespace
 


### PR DESCRIPTION
The boolean value `false` is a valid value for a Boolean element and should be rendered as any other value. However, when determining whether an element value should be included in the output of `to_xml`, the check is `elsif item`, which fails when `item == false`. As a result a Boolean element with value `false` currently is not included in the `to_xml` output. This patch fixes that.
