### PR TITLE
fix parsing of camelCased nodes

### DIFF
--- a/lib/happymapper/anonymous_mapper.rb
+++ b/lib/happymapper/anonymous_mapper.rb
@@ -96,9 +96,9 @@ module HappyMapper
         String
       end
 
-      method = class_instance.elements.find {|e| e.name == element.name } ? :has_many : :has_one
+      method = class_instance.elements.find {|e| e.name == underscore(element.name) } ? :has_many : :has_one
 
-      class_instance.send(method,underscore(element.name),element_type)
+      class_instance.send(method,underscore(element.name),element_type, tag: element.name)
     end
 
     #
@@ -106,7 +106,7 @@ module HappyMapper
     # the attribute provided.
     #
     def define_attribute_on_class(class_instance,attribute)
-      class_instance.attribute underscore(attribute.name), String
+      class_instance.attribute underscore(attribute.name), String, tag: attribute.name
     end
 
   end

--- a/spec/fixtures/address.xml
+++ b/spec/fixtures/address.xml
@@ -5,5 +5,8 @@
   <postcode>26131</postcode>
   <city>Oldenburg</city>
   <country code="de">Germany</country>
+  <mobilePhone operatorName='vodafone'>89473928231</mobilePhone>
+  <homeOwner>Albert</homeOwner>
+  <homeOwner>Mayer</homeOwner>
   <state>Lower Saxony</state>
 </address>

--- a/spec/happymapper_parse_spec.rb
+++ b/spec/happymapper_parse_spec.rb
@@ -15,6 +15,16 @@ describe HappyMapper do
         subject.city.should == "Oldenburg"
       end
 
+      it "should parse camelCased elements" do
+        subject.mobile_phone.content.should == '89473928231'
+      end
+
+      it "should recognize several camelCased elements as has_many relationship" do
+        subject.home_owner.size.should == 2
+        subject.home_owner.first == 'Albert'
+        subject.home_owner.last == 'Mayer'
+      end
+
       it "should not create a content entry when the xml contents no text content" do
         subject.should_not respond_to :content
       end
@@ -23,6 +33,10 @@ describe HappyMapper do
 
         it "should parse the attributes" do
           subject.country.code.should == "de"
+        end
+
+        it "should parse camelCased attributes" do
+          subject.mobile_phone.operator_name.should == "vodafone"
         end
 
         it "should parse the content" do


### PR DESCRIPTION
Hello, I tried to use happymapper and faced with several issues related to nodes with camelCased names:
1) happymapper couldn't get value of such nodes so it was nil
2) when I fixed first, I found that has_one/has_many works bad because of the same issue (it couldn't find repeating elements, because for node 'camelCase' was created element named 'camel_cased' and happymapper tried to find element by 'camelCase' name

I fixed that issues and wrote some specs to cover them, hope you'll find it useful :+1: 
