### PR TITLE
Work-around Rubinius build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,11 @@ rvm:
   - jruby-9.1.13.0
   - jruby-head
   - ruby-head
-  - rubinius-3
 matrix:
+  include:
+    - rvm: rubinius-3
+      env:
+        - RUBYOPT="-rbundler/deprecate"
   allow_failures:
     - rvm: jruby-9.1.13.0
     - rvm: jruby-head


### PR DESCRIPTION
This preload bundler/deprecate on Rubinius.

See https://github.com/bundler/bundler/issues/6163 for details.