### PR TITLE
Fix camel-cased name handling in anonymous parse

### DIFF
--- a/lib/happymapper/anonymous_mapper.rb
+++ b/lib/happymapper/anonymous_mapper.rb
@@ -95,7 +95,7 @@ module HappyMapper
 
       method = class_instance.elements.find { |e| e.name == element.name } ? :has_many : :has_one
 
-      class_instance.send(method, underscore(element.name), element_type)
+      class_instance.send(method, underscore(element.name), element_type, tag: element.name)
     end
 
     #
@@ -103,7 +103,7 @@ module HappyMapper
     # the attribute provided.
     #
     def define_attribute_on_class(class_instance, attribute)
-      class_instance.attribute underscore(attribute.name), String
+      class_instance.attribute underscore(attribute.name), String, tag: attribute.name
     end
   end
 end

--- a/spec/happymapper_parse_spec.rb
+++ b/spec/happymapper_parse_spec.rb
@@ -40,10 +40,21 @@ describe HappyMapper do
     context 'element names with camelCased elements and Capital Letters' do
       subject { described_class.parse fixture_file('subclass_namespace.xml') }
 
-      it 'should parse the elements and values correctly' do
-        expect(subject.title).to eq('article title')
+      it 'parses camel-cased child elements correctly' do
         expect(subject.photo.publish_options.author).to eq('Stephanie')
         expect(subject.gallery.photo.title).to eq('photo title')
+      end
+
+      it 'parses camel-cased child properties correctly' do
+        expect(subject.publish_options.created_day).to eq('2011-01-14')
+      end
+    end
+
+    context 'with elements with camelCased attribute names' do
+      subject { described_class.parse '<foo barBaz="quuz"/>' }
+
+      it 'parses attributes correctly' do
+        expect(subject.bar_baz).to eq('quuz')
       end
     end
 


### PR DESCRIPTION
Always specify the tag in child or attribute definitions. This ensures
that:

- Elements containing a string value are handled correctly
- Attributes are handled correctly

Elements containing a nested object were already handled correctly
because their class would have the tag specified.

Fixes #64.