### PR TITLE
Improve namespace handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 HappyMapper
 ===========
 
-Happymapper allows you to parse XML data and convert it quickly and easily into ruby data structures.
+Happymapper allows you to parse XML data and convert it quickly and easily into
+ruby data structures.
 
 This project is a fork of the great work done first by
 [jnunemaker](https://github.com/jnunemaker/happymapper).
@@ -13,7 +14,8 @@ This project is a fork of the great work done first by
   * Raw XML content parsing
   * `#to_xml` support utilizing the same HappyMapper tags
   * Numerous fixes for namespaces when using composition of classes
-  * Fixes for instances of XML where a namespace is defined but no elements with that namespace are found
+  * Fixes for instances of XML where a namespace is defined but no elements
+    with that namespace are found
 
 ## Installation
 
@@ -24,7 +26,7 @@ This project is a fork of the great work done first by
 ### [Bundler](http://gembundler.com/)
 Add the `nokogiri-happymapper` gem to your project's `Gemfile`.
 
-    gem 'nokogiri-happymapper', :require => 'happymapper'
+    gem 'nokogiri-happymapper', require: 'happymapper'
 
 Run the bundler command to install the gem:
 
@@ -32,7 +34,8 @@ Run the bundler command to install the gem:
 
 # Examples
 
-Let's start with a simple example to get our feet wet. Here we have a simple example of XML that defines some address information:
+Let's start with a simple example to get our feet wet. Here we have a simple
+example of XML that defines some address information:
 
     <address>
       <street>Milchstrasse</street>
@@ -42,11 +45,13 @@ Let's start with a simple example to get our feet wet. Here we have a simple exa
       <country code="de">Germany</country>
     </address>
 
-Happymapper provides support for simple, zero configuration parsing as well as the ability to model the XML content in classes.
+Happymapper provides support for simple, zero configuration parsing as well as
+the ability to model the XML content in classes.
 
 ## HappyMapper.parse(XML)
 
-With no classes or configuration you can parse the example XML with little effort:
+With no classes or configuration you can parse the example XML with little
+effort:
 
 ```ruby
 address = HappyMapper.parse(ADDRESS_XML_DATA)
@@ -60,9 +65,12 @@ address.country.content # => Germany
 
 It is important to be aware that this no configuration parsing is limited in capacity:
 
-* All element names are converted to accessor methods with [underscorized](http://rubydoc.info/gems/activesupport/ActiveSupport/Inflector:underscore) names
+* All element names are converted to accessor methods with
+  [underscorized](http://rubydoc.info/gems/activesupport/ActiveSupport/Inflector:underscore)
+  names
 * All value fields are left as String types
-* Determining if there is just one or multiple child elements is hard, so it assumes it is one until it finds another with the same name.
+* Determining if there is just one or multiple child elements is hard, so it
+  assumes it is one until it finds another with the same name.
 
 ## Address.parse(XML)
 
@@ -75,33 +83,44 @@ class Address
   include HappyMapper
 
   tag 'address'
-  element :street, String, :tag => 'street'
-  element :postcode, String, :tag => 'postcode'
-  element :housenumber, Integer, :tag => 'housenumber'
-  element :city, String, :tag => 'city'
-  element :country, String, :tag => 'country'
+  element :street, String, tag: 'street'
+  element :postcode, String, tag: 'postcode'
+  element :housenumber, Integer, tag: 'housenumber'
+  element :city, String, tag: 'city'
+  element :country, String, tag: 'country'
 end
 ```
 
-To make a class HappyMapper compatible you simply `include HappyMapper` within the class definition. This takes care of all the work of defining all the speciality methods and magic you need to get running. As you can see we immediately start using these methods.
+To make a class HappyMapper compatible you simply `include HappyMapper` within
+the class definition. This takes care of all the work of defining all the
+speciality methods and magic you need to get running. As you can see we
+immediately start using these methods.
 
 * `tag` matches the name of the XML tag name 'address'.
 
-* `element` defines accessor methods for the specified symbol (e.g. `:street`,`:housenumber`) that will return the class type (e.g. `String`,`Integer`) of the XML tag specified (e.g. `:tag => 'street'`, `:tag => 'housenumber'`).
+* `element` defines accessor methods for the specified symbol
+  (e.g. `:street`,`:housenumber`) that will return the class type
+  (e.g. `String`,`Integer`) of the XML tag specified
+  (e.g. `tag: 'street'`, `tag: 'housenumber'`).
 
-When you define an element with an accessor with the same name as the tag, this is the case for all the examples above, you can omit the `:tag`. These two element declaration are equivalent to each other:
+When you define an element with an accessor with the same name as the tag, this
+is the case for all the examples above, you can omit the `:tag`. These two
+element declaration are equivalent to each other:
 
 ```ruby
-element :street, String, :tag => 'street'
+element :street, String, tag: 'street'
 element :street, String
 ```
 
-Including the additional tag element is not going to hurt anything and in some cases will make it absolutely clear how these elements map to the XML. However, once you know this rule, it is hard not to want to save yourself the keystrokes.
+Including the additional tag element is not going to hurt anything and in some
+cases will make it absolutely clear how these elements map to the XML. However,
+once you know this rule, it is hard not to want to save yourself the
+keystrokes.
 
 Instead of `element` you may also use `has_one`:
 
 ```ruby
-element :street, String, :tag => 'street'
+element :street, String, tag: 'street'
 element :street, String
 has_one :street, String
 ```
@@ -110,29 +129,40 @@ These three statements are equivalent to each other.
 
 ## Parsing
 
-With the mapping of the address XML articulated in our Address class it is time to parse the data:
+With the mapping of the address XML articulated in our Address class it is time
+to parse the data:
 
 ```ruby
-address = Address.parse(ADDRESS_XML_DATA, :single => true)
+address = Address.parse(ADDRESS_XML_DATA, single: true)
 puts address.street
 ```
 
-Assuming that the constant `ADDRESS_XML_DATA` contains a string representation of the address XML data this is fairly straight-forward save for the `parse` method.
+Assuming that the constant `ADDRESS_XML_DATA` contains a string representation
+of the address XML data this is fairly straight-forward save for the `parse`
+method.
 
-The `parse` method, like `tag` and `element` are all added when you included HappyMapper in the class. Parse is a wonderful, magical place that converts all these declarations that you have made into the data structure you are about to know and love.
+The `parse` method, like `tag` and `element` are all added when you included
+HappyMapper in the class. Parse is a wonderful, magical place that converts all
+these declarations that you have made into the data structure you are about to
+know and love.
 
-But what about the `:single => true`? Right, that is because by default when your object is all done parsing it will be an array. In this case an array with one element, but an array none the less. So the following are equivalent to each other:
+But what about the `single: true`? Right, that is because by default when
+your object is all done parsing it will be an array. In this case an array with
+one element, but an array none the less. So the following are equivalent to
+each other:
 
 ```ruby
 address = Address.parse(ADDRESS_XML_DATA).first
-address = Address.parse(ADDRESS_XML_DATA, :single => true)
+address = Address.parse(ADDRESS_XML_DATA, single: true)
 ```
 
-The first one returns an array and we return the first instance, the second will do that work for us inside of parse.
+The first one returns an array and we return the first instance, the second
+will do that work for us inside of parse.
 
 ## Multiple Elements Mapping
 
-What if our address XML was a little different, perhaps we allowed multiple streets:
+What if our address XML was a little different, perhaps we allowed multiple
+streets:
 
     <address>
       <street>Milchstrasse</street>
@@ -143,20 +173,23 @@ What if our address XML was a little different, perhaps we allowed multiple stre
       <country code="de">Germany</country>
     </address>
 
-Similar to `element` or `has_one`, the declaration for when you have multiple elements you simply use:
+Similar to `element` or `has_one`, the declaration for when you have multiple
+elements you simply use:
 
 ```ruby
-has_many :streets, String, :tag => 'street'
+has_many :streets, String, tag: 'street'
 ```
 
 Your resulting `streets` method will now return an array.
 
 ```ruby
-address = Address.parse(ADDRESS_XML_DATA, :single => true)
+address = Address.parse(ADDRESS_XML_DATA, single: true)
 puts address.streets.join('\n')
 ```
 
-Imagine that you have to write `streets.join('\n')` for the rest of eternity throughout your code. It would be a nightmare and one that you could avoid by creating your own convenience method.
+Imagine that you have to write `streets.join('\n')` for the rest of eternity
+throughout your code. It would be a nightmare and one that you could avoid by
+creating your own convenience method.
 
 ```ruby
 require 'happymapper'
@@ -172,14 +205,15 @@ class Address
     @streets.join('\n')
   end
 
-  element :postcode, String, :tag => 'postcode'
-  element :housenumber, String, :tag => 'housenumber'
-  element :city, String, :tag => 'city'
-  element :country, String, :tag => 'country'
+  element :postcode, String, tag: 'postcode'
+  element :housenumber, String, tag: 'housenumber'
+  element :city, String, tag: 'city'
+  element :country, String, tag: 'country'
 end
 ```
 
-Now when we call the method `streets` we get a single value, but we still have the instance variable `@streets` if we ever need to the values as an array.
+Now when we call the method `streets` we get a single value, but we still have
+the instance variable `@streets` if we ever need to the values as an array.
 
 
 ## Attribute Mapping
@@ -196,10 +230,11 @@ Now when we call the method `streets` we get a single value, but we still have t
 Attributes are absolutely the same as `element` or `has_many`
 
 ```ruby
-attribute :location, String, :tag => 'location
+attribute :location, String, tag: 'location
 ```
 
-Again, you can omit the tag if the attribute accessor symbol matches the name of the attribute.
+Again, you can omit the tag if the attribute accessor symbol matches the name
+of the attribute.
 
 
 ### Attributes On Empty Child Elements
@@ -212,12 +247,14 @@ Again, you can omit the tag if the attribute accessor symbol matches the name of
       <updated>2011-07-10T06:52:27Z</updated>
     </feed>
 
-In this case you would need to map an element to a new `Link` class just to access `<link>`s attributes, except that there is an alternate syntax. Instead of
+In this case you would need to map an element to a new `Link` class just to
+access `<link>`s attributes, except that there is an alternate syntax. Instead
+of
 
 ```ruby
 class Feed
   # ....
-  has_many :links, Link, :tag => 'link', :xpath => '.'
+  has_many :links, Link, tag: 'link', xpath: '.'
 end
 
 class Link
@@ -232,17 +269,25 @@ end
 You can drop the `Link` class and simply replace the `has_many` on `Feed` with
 
 ```ruby
-element :link, String, :single => false, :attributes => { :rel => String, :type => String, :href => String }
+element :link, String, single: false, attributes: { rel: String, type: String, href: String }
 ```
 
-As there is no content, the type given for `:link` (`String` above) is irrelevant, but `nil` won't work and other types may try to perform typecasting and fail. You can omit the :single => false for elements that only occur once within their parent.
+As there is no content, the type given for `:link` (`String` above) is
+irrelevant, but `nil` won't work and other types may try to perform typecasting
+and fail. You can omit the single: false for elements that only occur once
+within their parent.
 
-This syntax is most appropriate for elements that (a) have attributes but no content and (b) only occur at only one level of the heirarchy. If `<feed>` contained another element that also contained a `<link>` (as atom feeds generally do) it would be DRY-er to use the first syntax, i.e. with a separate `Link` class.
+This syntax is most appropriate for elements that (a) have attributes but no
+content and (b) only occur at only one level of the heirarchy. If `<feed>`
+contained another element that also contained a `<link>` (as atom feeds
+generally do) it would be DRY-er to use the first syntax, i.e. with a separate
+`Link` class.
 
 
 ## Class composition (and Text Node)
 
-Our address has a country and that country element has a code. Up until this point we neglected it as we declared a `country` as being a `String`.
+Our address has a country and that country element has a code. Up until this
+point we neglected it as we declared a `country` as being a `String`.
 
     <address location='home'>
       <street>Milchstrasse</street>
@@ -278,33 +323,40 @@ class Address
 
   tag 'address'
 
-  has_many :streets, String, :tag => 'street'
+  has_many :streets, String, tag: 'street'
 
   def streets
     @streets.join('\n')
   end
 
-  element :postcode, String, :tag => 'postcode'
-  element :housenumber, String, :tag => 'housenumber'
-  element :city, String, :tag => 'city'
-  element :country, Country, :tag => 'country'
+  element :postcode, String, tag: 'postcode'
+  element :housenumber, String, tag: 'housenumber'
+  element :city, String, tag: 'city'
+  element :country, Country, tag: 'country'
 end
 ```
 
-Instead of `String`, `Boolean`, or `Integer` we say that it is a `Country` and HappyMapper takes care of the details of continuing the XML mapping through the country element.
+Instead of `String`, `Boolean`, or `Integer` we say that it is a `Country` and
+HappyMapper takes care of the details of continuing the XML mapping through the
+country element.
 
 ```ruby
-address = Address.parse(ADDRESS_XML_DATA, :single => true)
+address = Address.parse(ADDRESS_XML_DATA, single: true)
 puts address.country.code
 ```
 
-A quick note, in the above example we used the constant `Country`. We could have used `'Country'`. The nice part of using the latter declaration, enclosed in quotes, is that you do not have to define your class before this class. So Country and Address can live in separate files and as long as both constants are available when it comes time to parse you are golden.
+A quick note, in the above example we used the constant `Country`. We could
+have used `'Country'`. The nice part of using the latter declaration, enclosed
+in quotes, is that you do not have to define your class before this class. So
+Country and Address can live in separate files and as long as both constants
+are available when it comes time to parse you are golden.
 
 ## Custom XPATH
 
 ### Has One, Has Many
 
-Getting to elements deep down within your XML can be a little more work if you did not have xpath support. Consider the following example:
+Getting to elements deep down within your XML can be a little more work if you
+did not have xpath support. Consider the following example:
 
     <media>
       <gallery>
@@ -320,14 +372,17 @@ Getting to elements deep down within your XML can be a little more work if you d
       </picture>
     </media>
 
-You may want to map the sub-elements contained buried in the 'gallery' as top level items in the media. Traditionally you could use class composition to accomplish this task, however, using the xpath attribute you have the ability to shortcut some of that work.
+You may want to map the sub-elements contained buried in the 'gallery' as top
+level items in the media. Traditionally you could use class composition to
+accomplish this task, however, using the xpath attribute you have the ability
+to shortcut some of that work.
 
 ```ruby
 class Media
   include HappyMapper
 
-  has_one :title, String, :xpath => 'gallery/title'
-  has_one :link, String, :xpath => 'gallery/title/@href'
+  has_one :title, String, xpath: 'gallery/title'
+  has_one :link, String, xpath: 'gallery/title/@href'
 end
 ```
 
@@ -335,7 +390,8 @@ end
 
 ### Inheritance Approach
 
-While mapping XML to objects you may arrive at a point where you have two or more very similar structures.
+While mapping XML to objects you may arrive at a point where you have two or
+more very similar structures.
 
 ```ruby
 class Article
@@ -361,7 +417,9 @@ class Gallery
 end
 ```
 
-In this example there are definitely two similarities between our two pieces of content. So much so that you might be included to create an inheritance structure to save yourself some keystrokes.
+In this example there are definitely two similarities between our two pieces of
+content. So much so that you might be included to create an inheritance
+structure to save yourself some keystrokes.
 
 ```ruby
 class Content
@@ -417,12 +475,17 @@ class Gallery
 end
 ```
 
-Here, when we include `Content` in both of these classes the module method `#included` is called and our class is given as a parameter. So we take that opportunity to do some surgery and define our happymapper elements as well as any other methods that may rely on those instance variables that come along in the package.
+Here, when we include `Content` in both of these classes the module method
+`#included` is called and our class is given as a parameter. So we take that
+opportunity to do some surgery and define our happymapper elements as well as
+any other methods that may rely on those instance variables that come along in
+the package.
 
 
 ## Filtering with XPATH (non-greedy)
 
-I ran into a case where I wanted to capture all the pictures that were directly under media, but not the ones contained within a gallery.
+I ran into a case where I wanted to capture all the pictures that were directly
+under media, but not the ones contained within a gallery.
 
     <media>
       <gallery>
@@ -445,15 +508,15 @@ require 'happymapper'
 class Media
   include HappyMapper
 
-  has_many :galleries, Gallery, :tag => 'gallery'
-  has_many :pictures, Picture, :tag => 'picture'
+  has_many :galleries, Gallery, tag: 'gallery'
+  has_many :pictures, Picture, tag: 'picture'
 end
 ```
 
 However when I parsed the media xml the number of pictures returned to me was 2, not 1.
 
 ```ruby
-pictures = Media.parse(MEDIA_XML,:single => true).pictures
+pictures = Media.parse(MEDIA_XML,single: true).pictures
 pictures.length.should == 1   # => Failed Expectation
 ```
 
@@ -466,7 +529,7 @@ To limit an element from being greedy and only finding elements at the
 level of the current node you can specify an XPATH.
 
 ```ruby
-has_many :pictures, Picture, :tag => 'picture', :xpath => '.'
+has_many :pictures, Picture, tag: 'picture', xpath: '.'
 ```
 
 `.` states that we are only interested in pictures that can be found directly
@@ -475,7 +538,8 @@ under the current node. So when we parse again we will have only our one element
 
 ## Namespaces
 
-Obviously your XML and these trivial examples are easy to map and parse because they lack the treacherous namespaces that befall most XML files.
+Obviously your XML and these trivial examples are easy to map and parse because
+they lack the treacherous namespaces that befall most XML files.
 
 Perhaps our `address` XML is really swarming with namespaces:
 
@@ -488,7 +552,10 @@ Perhaps our `address` XML is really swarming with namespaces:
       <prefix:country code="de">Germany</prefix:country>
     </prefix:address>
 
-Here again is our address example with a made up namespace called `prefix` that comes direct to use from unicornland, a very magical place indeed. Well we are going to have to do some work on our class definition and that simply adding this one liner to the `Address` class:
+Here again is our address example with a made up namespace called `prefix` that
+comes direct to use from unicornland, a very magical place indeed. Well we are
+going to have to do some work on our class definition and that simply adding
+this one liner to the `Address` class:
 
 ```ruby
 class Address
@@ -500,17 +567,21 @@ class Address
 end
 ```
 
-Of course, if that is too easy for you, you can append a `:namespace => 'prefix` to every one of the elements that you defined.
+Of course, if that is too easy for you, you can append a `namespace: 'prefix`
+to every one of the elements that you defined.
 
 ```ruby
-has_many :street, String, :tag => 'street', :namespace => 'prefix'
-element :postcode, String, :tag => 'postcode', :namespace => 'prefix'
-element :housenumber, String, :tag => 'housenumber', :namespace => 'prefix'
-element :city, String, :tag => 'city', :namespace => 'prefix'
-element :country, Country, :tag => 'country', :namespace => 'prefix'
+has_many :street, String, tag: 'street', namespace: 'prefix'
+element :postcode, String, tag: 'postcode', namespace: 'prefix'
+element :housenumber, String, tag: 'housenumber', namespace: 'prefix'
+element :city, String, tag: 'city', namespace: 'prefix'
+element :country, Country, tag: 'country', namespace: 'prefix'
 ```
 
-I definitely recommend the former, as it saves you a whole hell of lot of typing. However, there are times when appending a namespace to an element declaration is important and that is when it has a different namespace then `namespsace 'prefix'`.
+I definitely recommend the former, as it saves you a whole hell of lot of
+typing. However, there are times when appending a namespace to an element
+declaration is important and that is when it has a different namespace than
+`namespace 'prefix'`.
 
 Imagine that our `country` actually belonged to a completely different namespace.
 
@@ -527,47 +598,58 @@ Imagine that our `country` actually belonged to a completely different namespace
 Well we would need to specify that namespace:
 
 ```ruby
-element :country, Country, :tag => 'country', :namespace => 'different'
+element :country, Country, tag: 'country', namespace: 'different'
 ```
 
 With that we should be able to parse as we once did.
 
 ## Large Datasets (in_groups_of)
 
-When dealing with large sets of XML that simply cannot or should not be placed into memory the objects can be handled in groups through the `:in_groups_of` parameter.
+When dealing with large sets of XML that simply cannot or should not be placed
+into memory the objects can be handled in groups through the `:in_groups_of`
+parameter.
 
 ```ruby
-Address.parse(LARGE_ADDRESS_XML_DATA,:in_groups_of => 5) do |group|
+Address.parse(LARGE_ADDRESS_XML_DATA,in_groups_of: 5) do |group|
   puts address.streets
 end
 ```
 
-This trivial block will parse the large set of XML data and in groups of 5 addresses at a time display the streets.
+This trivial block will parse the large set of XML data and in groups of 5
+addresses at a time display the streets.
 
 ## Saving to XML
 
-Saving a class to XML is as easy as calling `#to_xml`.  The end result will be the current state of your object represented as xml. Let's cover some details that are sometimes necessary and features present to make your life easier.
+Saving a class to XML is as easy as calling `#to_xml`.  The end result will be
+the current state of your object represented as xml. Let's cover some details
+that are sometimes necessary and features present to make your life easier.
 
 
 ### :on_save
 
-When you are saving data to xml it is often important to change or manipulate data to a particular format. For example, a time object:
+When you are saving data to xml it is often important to change or manipulate
+data to a particular format. For example, a time object:
 
 ```ruby
-has_one :published_time, Time, :on_save => lambda {|time| time.strftime("%H:%M:%S") if time }
+has_one :published_time, Time, on_save: lambda {|time| time.strftime("%H:%M:%S") if time }
 ```
 
-Here we add the options `:on_save` and specify a lambda which will be executed on the method call to `:published_time`.
+Here we add the options `:on_save` and specify a lambda which will be executed
+on the method call to `:published_time`.
 
 ### :state_when_nil
 
-When an element contains a nil value, or perhaps the result of the :on_save lambda correctly results in a nil value you will be happy that the element will not appear in the resulting XML. However, there are time when you will want to see that element and that's when `:state_when_nil` is there for you.
+When an element contains a nil value, or perhaps the result of the :on_save
+lambda correctly results in a nil value you will be happy that the element will
+not appear in the resulting XML. However, there are time when you will want to
+see that element and that's when `:state_when_nil` is there for you.
 
 ```ruby
-has_one :favorite_color, String, :state_when_nil => true
+has_one :favorite_color, String, state_when_nil: true
 ```
 
-The resulting XML will include the 'favorite_color' element even if the favorite color has not been specified.
+The resulting XML will include the 'favorite_color' element even if the
+favorite color has not been specified.
 
 ### :read_only
 
@@ -575,15 +657,17 @@ When an element, attribute, or text node is a value that you have no interest in
 saving to XML, you can ensure that takes place by stating that it is `read only`.
 
 ```ruby
-has_one :modified, Boolean, :read_only => true
-attribute :temporary, Boolean, :read_only => true
+has_one :modified, Boolean, read_only: true
+attribute :temporary, Boolean, read_only: true
 ```
 
 This is useful if perhaps the incoming XML is different than the out-going XML.
 
 ### namespaces
 
-Parsing the XML to objects only required you to simply specify the prefix of the namespace you wanted to parse, when you persist to xml you will need to define your namespaces so that they are correctly captured.
+Parsing the XML to objects only required you to simply specify the prefix of
+the namespace you wanted to parse, when you persist to xml you will need to
+define your namespaces so that they are correctly captured.
 
 ```ruby
 class Address
@@ -599,7 +683,7 @@ class Address
   element :postcode, String
   element :housenumber, String
   element :city, String
-  element :country, Country, :tag => 'country', :namespace => 'different'
+  element :country, Country, tag: 'country', namespace: 'different'
 
 end
 ```

--- a/lib/happymapper/anonymous_mapper.rb
+++ b/lib/happymapper/anonymous_mapper.rb
@@ -95,7 +95,12 @@ module HappyMapper
 
       method = class_instance.elements.find { |e| e.name == element.name } ? :has_many : :has_one
 
-      class_instance.send(method, underscore(element.name), element_type, tag: element.name)
+      options = {}
+      options[:tag] = element.name
+      namespace = element.namespace
+      options[:namespace] = namespace.prefix if namespace
+
+      class_instance.send(method, underscore(element.name), element_type, options)
     end
 
     #

--- a/lib/happymapper/attribute.rb
+++ b/lib/happymapper/attribute.rb
@@ -16,7 +16,7 @@ module HappyMapper
       if options[:xpath]
         yield(node.xpath(options[:xpath], xpath_options))
       else
-        yield(node[tag])
+        yield(node.attributes[tag])
       end
     end
   end

--- a/spec/happymapper_parse_spec.rb
+++ b/spec/happymapper_parse_spec.rb
@@ -81,6 +81,10 @@ describe HappyMapper do
       it 'should parse the elements an values correctly' do
         expect(subject.title).to eq('article title')
       end
+
+      it 'parses attribute names correctly' do
+        expect(subject.name).to eq 'title'
+      end
     end
 
     context 'after_parse callbacks' do

--- a/spec/happymapper_parse_spec.rb
+++ b/spec/happymapper_parse_spec.rb
@@ -87,6 +87,21 @@ describe HappyMapper do
       end
     end
 
+    context 'with value elements with different namespace' do
+      let(:xml) do
+        <<~XML
+          <a:foo xmlns:a="http://foo.org/a" xmlns:b="http://foo.org/b">
+            <b:bar>Hello</b:bar>
+          </a:foo>
+        XML
+      end
+      let(:result) { described_class.parse xml }
+
+      it 'parses the value elements correctly' do
+        expect(result.bar).to eq 'Hello'
+      end
+    end
+
     context 'after_parse callbacks' do
       module AfterParseSpec
         class Address


### PR DESCRIPTION
- Handle namespaces for nested value elements when parsing anonymously.
- Handle attributes with a namespace that is different from the element
  namespace.

This fixes #65.