### PR TITLE
Ensure #to_xml generates UTF-8 content

### DIFF
--- a/lib/happymapper.rb
+++ b/lib/happymapper.rb
@@ -726,7 +726,7 @@ module HappyMapper
     # xml generated from the object. If an XML builder instance was specified
     # then we assume that has been called recursively to generate a larger
     # XML document.
-    write_out_to_xml ? builder.to_xml : builder
+    write_out_to_xml ? builder.to_xml.force_encoding('UTF-8') : builder
   end
 
   # Parse the xml and update this instance. This does not update instances

--- a/spec/happymapper_spec.rb
+++ b/spec/happymapper_spec.rb
@@ -1120,4 +1120,14 @@ describe HappyMapper do
       expect(address.xml_content).to eq %(<street>Milchstrasse</street><housenumber>23</housenumber>)
     end
   end
+
+  describe '#to_xml' do
+    let(:original) { '<foo><bar>baz</bar></foo>' }
+    let(:parsed) { described_class.parse original}
+
+    it 'has UTF-8 encoding by default' do
+      expect(original.encoding).to eq Encoding::UTF_8
+      expect(parsed.to_xml.encoding).to eq Encoding::UTF_8
+    end
+  end
 end


### PR DESCRIPTION
This is a workaround for https://github.com/sparklemotion/nokogiri/issues/1659.

See also #53.