### PR TITLE
Bail out early for content elements

### DIFF
--- a/lib/happymapper/anonymous_mapper.rb
+++ b/lib/happymapper/anonymous_mapper.rb
@@ -79,7 +79,10 @@ module HappyMapper
       # HappyMapper content attribute if the text happens to contain
       # some content.
 
-      class_instance.content :content, String if element.text? && (element.content.strip != '')
+      if element.text?
+        class_instance.content :content, String if element.content.strip != ''
+        return
+      end
 
       # When the element has children elements, that are not text
       # elements, then we want to recursively define a new HappyMapper

--- a/spec/happymapper/anonymous_mapper_spec.rb
+++ b/spec/happymapper/anonymous_mapper_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe HappyMapper::AnonymousMapper do
     context 'when parsing a single root node' do
       let(:parsed_result) { anonymous_mapper.parse fixture_file('address.xml') }
 
+      it 'creates the correct set of child elements on the element class' do
+        elements = parsed_result.class.elements
+        expect(elements.map(&:tag)).to eq %w(street housenumber postcode city country state)
+      end
+
       it 'parses child elements' do
         aggregate_failures do
           expect(parsed_result.street).to eq('Milchstrasse')


### PR DESCRIPTION
This avoids creating extra `:text` elements whenever a node has text content.