### PR TITLE
Fix anonymous parsing nesting

### DIFF
--- a/lib/happymapper/anonymous_mapper.rb
+++ b/lib/happymapper/anonymous_mapper.rb
@@ -100,6 +100,7 @@ module HappyMapper
       options[:tag] = element.name
       namespace = element.namespace
       options[:namespace] = namespace.prefix if namespace
+      options[:xpath] = './' unless element_type == String
 
       class_instance.send(method, underscore(element.name), element_type, options)
     end

--- a/spec/features/same_tag_different_meaning_spec.rb
+++ b/spec/features/same_tag_different_meaning_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'parsing the same tag differently in different contexts' do
+  module SameTagSpec
+    class Bar
+      include HappyMapper
+      has_one :baz, String
+    end
+
+    class Baz
+      include HappyMapper
+      has_one :qux, String
+    end
+
+    class Foo
+      include HappyMapper
+      has_one :bar, Bar
+      has_one :baz, Baz, xpath: '.'
+    end
+  end
+
+  let(:xml) do
+    <<~XML
+      <foo>
+        <bar>
+          <baz>Hello</baz>
+        </bar>
+        <baz>
+          <qux>Hi</qux>
+        </baz>
+      </foo>
+    XML
+  end
+
+  it 'parses both uses correctly if xpath limits recursion' do
+    result = SameTagSpec::Foo.parse xml
+    aggregate_failures do
+      expect(result.bar.baz).to eq 'Hello'
+      expect(result.baz.qux).to eq 'Hi'
+    end
+  end
+end

--- a/spec/happymapper/anonymous_mapper_spec.rb
+++ b/spec/happymapper/anonymous_mapper_spec.rb
@@ -111,5 +111,28 @@ RSpec.describe HappyMapper::AnonymousMapper do
         expect(result.bar).to eq 'Hello'
       end
     end
+
+    context 'when parsing xml that uses the same tag for string and other elements' do
+      let(:xml) do
+        <<~XML
+          <foo>
+            <bar>
+              <baz>Hello</baz>
+            </bar>
+            <baz>
+              <qux>Hi</qux>
+            </baz>
+          </foo>
+        XML
+      end
+      let(:result) { anonymous_mapper.parse xml }
+
+      it 'parses both occurences of the tag correctly' do
+        aggregate_failures do
+          expect(result.bar.baz).to eq 'Hello'
+          expect(result.baz.qux).to eq 'Hi'
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Anonymous parsing will create elements for every level of the provided XML. Therefore, it doesn't make sense to use the default behavior of finding child elements using the greedy xpath expression `.//`. This PR makes the anonymous elements use `./` instead, so only find direct child elements.

In particular, this solves the problem where a tag is re-used in a nested child for a different purpose, causing parse failures. For example, take the following XML:

```xml
<foo>
  <bar>
    <baz>Hello</baz>
  </bar>
  <baz>
    <qux>Hi</qux>
  </baz>
</foo>
```

The anonymous mapper would create a `has_one :baz` relation on the parser class for `<foo>`. Since the nested `<baz>` occurs first in the document, it would assign that element to `foo.baz`, and drop the 'real' child `<baz>` entirely.

An alternative solution would be to search for all nested `<baz>` elements and create a `has_many` relationship. However, this would make the result a less clear mapping of the provided XML structure.