### PR TITLE
Fix anonymous has_many with camel case

### DIFF
--- a/lib/happymapper/anonymous_mapper.rb
+++ b/lib/happymapper/anonymous_mapper.rb
@@ -88,7 +88,7 @@ module HappyMapper
       # nodes, then we want to recursively define a new HappyMapper
       # class that will have elements and attributes.
 
-      element_type = if !node.elements.reject(&:text?).empty? || !node.attributes.empty?
+      element_type = if node.elements.any? || node.attributes.any?
                        create_happymapper_class_from_node(node)
                      else
                        String

--- a/lib/happymapper/anonymous_mapper.rb
+++ b/lib/happymapper/anonymous_mapper.rb
@@ -94,7 +94,8 @@ module HappyMapper
                        String
                      end
 
-      method = class_instance.elements.find { |e| e.name == element.name } ? :has_many : :has_one
+      element_name = underscore(element.name)
+      method = class_instance.elements.find { |e| e.name == element_name } ? :has_many : :has_one
 
       options = {}
       options[:tag] = element.name
@@ -102,7 +103,7 @@ module HappyMapper
       options[:namespace] = namespace.prefix if namespace
       options[:xpath] = './' unless element_type == String
 
-      class_instance.send(method, underscore(element.name), element_type, options)
+      class_instance.send(method, element_name, element_type, options)
     end
 
     #

--- a/lib/happymapper/anonymous_mapper.rb
+++ b/lib/happymapper/anonymous_mapper.rb
@@ -7,13 +7,13 @@ module HappyMapper
       #   to handle which includes the text, xml document, node, fragment, etc.
       xml = Nokogiri::XML(xml_content)
 
-      happymapper_class = create_happymapper_class_with_element(xml.root)
+      klass = create_happymapper_class_from_node(xml.root)
 
       # With all the elements and attributes defined on the class it is time
       # for the class to actually use the normal HappyMapper powers to parse
       # the content. At this point this code is utilizing all of the existing
       # code implemented for parsing.
-      happymapper_class.parse(xml_content, single: true)
+      klass.parse(xml_content, single: true)
     end
 
     private
@@ -38,80 +38,80 @@ module HappyMapper
     # value is set to the one provided.
     #
     def create_happymapper_class_with_tag(tag_name)
-      happymapper_class = Class.new
-      happymapper_class.class_eval do
+      klass = Class.new
+      klass.class_eval do
         include HappyMapper
         tag tag_name
       end
-      happymapper_class
+      klass
     end
 
     #
     # Used internally to create and define the necessary happymapper
     # elements.
     #
-    def create_happymapper_class_with_element(element)
-      happymapper_class = create_happymapper_class_with_tag(element.name)
+    def create_happymapper_class_from_node(node)
+      klass = create_happymapper_class_with_tag(node.name)
 
-      happymapper_class.namespace element.namespace.prefix if element.namespace
+      klass.namespace node.namespace.prefix if node.namespace
 
-      element.namespaces.each do |prefix, namespace|
-        happymapper_class.register_namespace prefix, namespace
+      node.namespaces.each do |prefix, namespace|
+        klass.register_namespace prefix, namespace
       end
 
-      element.attributes.each_value do |attribute|
-        define_attribute_on_class(happymapper_class, attribute)
+      node.attributes.each_value do |attribute|
+        define_attribute_on_class(klass, attribute)
       end
 
-      element.children.each do |child|
-        define_element_on_class(happymapper_class, child)
+      node.children.each do |child|
+        define_element_on_class(klass, child)
       end
 
-      happymapper_class
+      klass
     end
 
     #
     # Define a HappyMapper element on the provided class based on
-    # the element provided.
+    # the node provided.
     #
-    def define_element_on_class(class_instance, element)
-      # When a text element has been provided create the necessary
+    def define_element_on_class(klass, node)
+      # When a text node has been provided create the necessary
       # HappyMapper content attribute if the text happens to contain
       # some content.
 
-      if element.text?
-        class_instance.content :content, String if element.content.strip != ''
+      if node.text?
+        klass.content :content, String if node.content.strip != ''
         return
       end
 
-      # When the element has children elements, that are not text
-      # elements, then we want to recursively define a new HappyMapper
+      # When the node has child elements, that are not text
+      # nodes, then we want to recursively define a new HappyMapper
       # class that will have elements and attributes.
 
-      element_type = if !element.elements.reject(&:text?).empty? || !element.attributes.empty?
-                       create_happymapper_class_with_element(element)
+      element_type = if !node.elements.reject(&:text?).empty? || !node.attributes.empty?
+                       create_happymapper_class_from_node(node)
                      else
                        String
                      end
 
-      element_name = underscore(element.name)
-      method = class_instance.elements.find { |e| e.name == element_name } ? :has_many : :has_one
+      element_name = underscore(node.name)
+      method = klass.elements.find { |e| e.name == element_name } ? :has_many : :has_one
 
       options = {}
-      options[:tag] = element.name
-      namespace = element.namespace
+      options[:tag] = node.name
+      namespace = node.namespace
       options[:namespace] = namespace.prefix if namespace
       options[:xpath] = './' unless element_type == String
 
-      class_instance.send(method, element_name, element_type, options)
+      klass.send(method, element_name, element_type, options)
     end
 
     #
     # Define a HappyMapper attribute on the provided class based on
     # the attribute provided.
     #
-    def define_attribute_on_class(class_instance, attribute)
-      class_instance.attribute underscore(attribute.name), String, tag: attribute.name
+    def define_attribute_on_class(klass, attribute)
+      klass.attribute underscore(attribute.name), String, tag: attribute.name
     end
   end
 end

--- a/lib/happymapper/item.rb
+++ b/lib/happymapper/item.rb
@@ -28,7 +28,7 @@ module HappyMapper
     end
 
     #
-    # @param [XMLNode] node the xml node that is being parsed
+    # @param [Nokogiri::XML::Element] node the xml node that is being parsed
     # @param [String] namespace the name of the namespace
     # @param [Hash] xpath_options additional xpath options
     #

--- a/spec/happymapper/anonymous_mapper_spec.rb
+++ b/spec/happymapper/anonymous_mapper_spec.rb
@@ -58,6 +58,26 @@ RSpec.describe HappyMapper::AnonymousMapper do
       end
     end
 
+    context 'with repeated elements with camel-cased names' do
+      let(:xml) do
+        <<~XML
+          <foo>
+            <fooBar>
+              <baz>Hello</baz>
+            </fooBar>
+            <fooBar>
+              <baz>Hi</baz>
+            </fooBar>
+          </foo>
+        XML
+      end
+      let(:parsed_result) { anonymous_mapper.parse xml }
+
+      it 'parses the repeated elements correctly' do
+        expect(parsed_result.foo_bar.map(&:baz)).to eq %w(Hello Hi)
+      end
+    end
+
     context 'with elements with camelCased attribute names' do
       let(:parsed_result) { anonymous_mapper.parse '<foo barBaz="quuz"/>' }
 


### PR DESCRIPTION
Fixes anonymous mapping when a node contains multiple child elements with a tag that uses camel case. The existing implementation would fail to detect that multiple elements were present.