### PR TITLE
Allow requiring 'nokogiri-happymapper'

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Or add the `nokogiri-happymapper` gem to your project's `Gemfile`.
 
     gem 'nokogiri-happymapper', require: 'happymapper'
 
+You can now also require `nokogiri-happymapper` directly.
+
+    gem 'nokogiri-happymapper'
+
 Run Bundler to install the gem:
 
     $ bundle install

--- a/lib/nokogiri-happymapper.rb
+++ b/lib/nokogiri-happymapper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# TODO: Deprecate requiring 'happymapper' in favor of 'nokogiri-happymapper'.
+require 'happymapper'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,7 @@ end
 
 require 'rspec'
 
-require 'happymapper'
+require 'nokogiri-happymapper'
 
 def fixture_file(filename)
   File.read(File.dirname(__FILE__) + "/fixtures/#{filename}")


### PR DESCRIPTION
This is more intuitive and simplifies use with Bundler.

Fixes #46.