### PR TITLE
Adds support for nested elements named 'class'

### DIFF
--- a/spec/features/attributes_spec.rb
+++ b/spec/features/attributes_spec.rb
@@ -7,6 +7,7 @@ module AttributeMethodConversion
     include HappyMapper
 
     has_many :link, String, attributes: { 'data-src': String, type: String, href: String }
+    has_one :class, String
   end
 end
 


### PR DESCRIPTION
Defining an item named 'class', as in
```
class Msg
  include HappyMapper

  has_one :'class', String
end

Msg.parse('<msg></msg>')
```
currently fails with
`lib/happymapper.rb:489:in `initialize': undefined method `attributes' for nil:NilClass (NoMethodError)`

The reason is that the .class method of the HappyMapper object is
overridden and all uses of self.class, starting with the one in
`initialize`, will fail.

The spec modification in this commit demonstrates another aspect of this
problem (when applied without the other changes) and can serve as a guard
against regression.

The fix is to add __class__ as an alias of class. Of course, if anyone ever
needs __class__ as an item, they will run into the same problem.
However, a generic solution adds a lot more complexity and needing __class__
is (much?) less likely than 'class'.