### PR TITLE
Emit attributes even when a default value is specified

### DIFF
--- a/lib/happymapper.rb
+++ b/lib/happymapper.rb
@@ -641,7 +641,6 @@ module HappyMapper
       else
 
         value = send(attribute.method_name)
-        value = nil if value == attribute.default
 
         #
         # Apply any on_save lambda/proc or value defined on the attribute.


### PR DESCRIPTION
HappyMapper's current behavior does not allow support for XSDs that specify default values for attributes while also specifying  `use="required"`, meaning they must always be present in XML messages conforming to the schema. Some w3c XSD's use this combination. Since HappyMapper does not support specifying whether an attribute is required, you currently need a workaround to ensure such an attribute is always emitted.

To change this, we cannot support the optimization of not emitting attributes that have a default value. To support that again, Attribute would need a `use`, `optional` or `required` option to specify the desired behavior.