### PR TITLE
Emit attributes when state_when_nil is true, independent of value

### DIFF
--- a/lib/happymapper.rb
+++ b/lib/happymapper.rb
@@ -652,7 +652,7 @@ module HappyMapper
         # Attributes that have a nil value should be ignored unless they explicitly
         # state that they should be expressed in the output.
         #
-        if !(value.nil? || attribute.options[:state_when_nil])
+        if !value.nil? || attribute.options[:state_when_nil]
           attribute_namespace = attribute.options[:namespace]
           ["#{attribute_namespace ? "#{attribute_namespace}:" : ''}#{attribute.tag}", value]
         else


### PR DESCRIPTION
Attributes with option `:state_when_nil` set are intended to have special behavior when their value is nil: they should be emitted anyway. However, the previous code never did so: the first term of the if clause would evaluate to true and the second term would never be evaluated.

This commit changes it so the attribute is actually emitted when the value is nil and `:state_when_nil` is set.