### PR TITLE
Loosen development dependency on simplecov

### DIFF
--- a/nokogiri-happymapper.gemspec
+++ b/nokogiri-happymapper.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rubocop', '~> 0.89.1')
   s.add_development_dependency('rubocop-performance', ['~> 1.7.1'])
   s.add_development_dependency('rubocop-rspec', '~> 1.43.1')
-  s.add_development_dependency('simplecov', ['~> 0.18.0'])
+  s.add_development_dependency('simplecov', ['>= 0.18.0', '< 0.20.0'])
 end


### PR DESCRIPTION
Loosening the dependency like this allows the build to run with the latest version of simplecov on modern Rubies, while using the older version on Ruby 2.4.