### PR TITLE
Prefer contain_exactly over match_array for literal arrays

### DIFF
--- a/spec/features/wildcard_tag_name_spec.rb
+++ b/spec/features/wildcard_tag_name_spec.rb
@@ -91,8 +91,8 @@ RSpec.describe 'classes with a wildcard tag' do
   describe '.parse' do
     it 'maps different elements to same class' do
       aggregate_failures do
-        expect(root.blargs).to match_array [GenericBase::Wild, GenericBase::Wild]
-        expect(root.jellos).to match_array [GenericBase::Wild]
+        expect(root.blargs).to contain_exactly(GenericBase::Wild, GenericBase::Wild)
+        expect(root.jellos).to contain_exactly(GenericBase::Wild)
       end
     end
 

--- a/spec/happymapper_spec.rb
+++ b/spec/happymapper_spec.rb
@@ -991,7 +991,7 @@ describe HappyMapper do
   it 'allows speficying child element class with a string' do
     bar = StringFoo::Bar.parse '<bar><thing/></bar>'
 
-    expect(bar.things).to match_array [StringFoo::Thing]
+    expect(bar.things).to contain_exactly(StringFoo::Thing)
   end
 
   it 'parses family search xml' do


### PR DESCRIPTION
Fixes RSpec/MatchArray offenses.
