### PR TITLE
Bump RuboCop dependency versions and update configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,10 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 2.7
 
+# Put development dependencies in the gemspec so rubygems.org knows about them
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
+
 # Spaces in strings with line continuations go at the beginning of the line.
 Layout/LineContinuationLeadingSpace:
   EnforcedStyle: leading

--- a/nokogiri-happymapper.gemspec
+++ b/nokogiri-happymapper.gemspec
@@ -35,9 +35,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rake-manifest', '~> 0.2.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 1.41'
+  spec.add_development_dependency 'rubocop', '~> 1.52'
   spec.add_development_dependency 'rubocop-packaging', '~> 0.5.2'
-  spec.add_development_dependency 'rubocop-performance', '~> 1.15'
-  spec.add_development_dependency 'rubocop-rspec', '~> 2.16'
+  spec.add_development_dependency 'rubocop-performance', '~> 1.18'
+  spec.add_development_dependency 'rubocop-rspec', '~> 2.22'
   spec.add_development_dependency 'simplecov', '~> 0.22.0'
 end


### PR DESCRIPTION
- Bump versions for rubocop dependencies
- Require development dependencies to be in the gemspec
