### PR TITLE
Improve custom parser option

### DIFF
--- a/lib/happymapper/item.rb
+++ b/lib/happymapper/item.rb
@@ -35,12 +35,12 @@ module HappyMapper
     def from_xml_node(node, namespace, xpath_options)
       namespace = options[:namespace] if options.key?(:namespace)
 
-      if suported_type_registered?
+      if custom_parser_defined?
+        find(node, namespace, xpath_options) { |n| process_node_with_custom_parser(n) }
+      elsif suported_type_registered?
         find(node, namespace, xpath_options) { |n| process_node_as_supported_type(n) }
       elsif constant == XmlContent
         find(node, namespace, xpath_options) { |n| process_node_as_xml_content(n) }
-      elsif custom_parser_defined?
-        find(node, namespace, xpath_options) { |n| process_node_with_custom_parser(n) }
       else
         process_node_with_default_parser(node, namespaces: xpath_options)
       end

--- a/lib/happymapper/item.rb
+++ b/lib/happymapper/item.rb
@@ -118,17 +118,21 @@ module HappyMapper
                 node.to_s
               end
 
-      custom_parser = options[:parser]
+      custom_parser = create_custom_parser(options[:parser])
 
       begin
-        if custom_parser.respond_to?(:call)
-          custom_parser.call(value)
-        else
-          constant.send(custom_parser.to_sym, value)
-        end
+        custom_parser.call(value)
       rescue StandardError
         nil
       end
+    end
+
+    def create_custom_parser(parser)
+      return parser if parser.respond_to?(:call)
+
+      proc { |value|
+        constant.send(parser.to_sym, value)
+      }
     end
 
     def process_node_with_default_parser(node, parse_options)

--- a/lib/happymapper/item.rb
+++ b/lib/happymapper/item.rb
@@ -118,8 +118,14 @@ module HappyMapper
                 node.to_s
               end
 
+      custom_parser = options[:parser]
+
       begin
-        constant.send(options[:parser].to_sym, value)
+        if custom_parser.respond_to?(:call)
+          custom_parser.call(value)
+        else
+          constant.send(custom_parser.to_sym, value)
+        end
       rescue StandardError
         nil
       end

--- a/spec/fixtures/custom_parsers.xml
+++ b/spec/fixtures/custom_parsers.xml
@@ -1,0 +1,3 @@
+<parsertest numbers="1,2,3">
+  <strings>a, b, c</strings>
+</parsertest>

--- a/spec/fixtures/custom_parsers.xml
+++ b/spec/fixtures/custom_parsers.xml
@@ -1,3 +1,4 @@
 <parsertest numbers="1,2,3">
   <strings>a, b, c</strings>
+  <bool>0</bool>
 </parsertest>

--- a/spec/happymapper_spec.rb
+++ b/spec/happymapper_spec.rb
@@ -559,6 +559,24 @@ module StringFoo
   end
 end
 
+class ParserTest
+  include HappyMapper
+
+  class Coerce
+    def self.number_list(val)
+      val.to_s.split(',').map(&:strip).map(&:to_i)
+    end
+  end
+
+  tag 'parsertest'
+  attribute :numbers, Coerce, parser: :number_list
+  element :strings, self, parser: :string_list
+
+  def self.string_list(val)
+    val.to_s.split(',').map(&:strip)
+  end
+end
+
 describe HappyMapper do
   describe 'being included into another class' do
     let(:klass) do
@@ -1206,6 +1224,15 @@ describe HappyMapper do
         expect(original.encoding).to eq Encoding::UTF_8
         expect(parsed.to_xml.encoding).to eq Encoding::UTF_8
       end
+    end
+  end
+
+  it 'parses with custom parser' do
+    parsed = ParserTest.parse fixture_file('custom_parsers.xml')
+
+    aggregate_failures do
+      expect(parsed.numbers).to eq [1, 2, 3]
+      expect(parsed.strings).to eq %w(a b c)
     end
   end
 end

--- a/spec/happymapper_spec.rb
+++ b/spec/happymapper_spec.rb
@@ -571,6 +571,7 @@ class ParserTest
   tag 'parsertest'
   attribute :numbers, Coerce, parser: :number_list
   element :strings, self, parser: :string_list
+  element :bool, String, parser: ->(val) { val.to_s == '1' }
 
   def self.string_list(val)
     val.to_s.split(',').map(&:strip)
@@ -1233,6 +1234,7 @@ describe HappyMapper do
     aggregate_failures do
       expect(parsed.numbers).to eq [1, 2, 3]
       expect(parsed.strings).to eq %w(a b c)
+      expect(parsed.bool).to be false
     end
   end
 end


### PR DESCRIPTION
I have an XML from an author who doesn't really understand XML, and would like to use HappyMapper to parse it.

The file contains things like:

```xml
<funder ids="1, 23, 42">
  <config>
    <lift>1</lift>
    <bus>0</lift>
  </config>
</funder>
```

and the parsed object

```ruby
should have_attributes(
  ids: [1, 23, 42],
  config: have_attributes(
    lift: true,
    bus:  false,
  ),
)
```

Luckily, `HappyMapper::Item` has a hidden feature to support custom parsers. However, it isn't particularly well tested, nor easy to use. My initial attempt was this:

```ruby
class Funder
  class Config
    include HappyMapper
    element :lift, Integer, parser: ->(val) { val == "1" }
    element :bus, Integer, parser: ->(val) { val == "1" }
  end

  include HappyMapper
  attribute :ids, Integer, parser: ->(val) { val.split(",").map { _1.strip.to_i } }
  element :config, Config
end
```

However, the actual syntax is something like this:

```ruby
# reusable coercion methods
module Helper
  def self.bool_from_int(val)
    val.to_s == "1"
  end
end

class Funder
  class Config
    include HappyMapper
    element :lift, Helper, parser: :bool_from_int
    element :bus, Helper, parser: :bool_from_int
  end

  include HappyMapper
  attribute :ids, self, parser: :parse_int_list
  element :config, Config

  def self.parse_int_list(val)
    val.split(",").map { _1.strip.to_i }
  end
end
```

For one-off-conversion, like for `Funder#ids` this feels weird.

This PR brings two things:

1. It adds some explicit tests for the `:parser` option.
2. It allows to use procs or lambdas (anything responding to `#call`, really) as `:parser`.

In order to use sth. like `attribute .., Integer, parser: ..` and avoid `attribute .., self, parser: ..`, the custom parser option now takes precedence over built-in parsers (from `HappyMapper::SupportedTypes`).

~~(Note: The CI currently fails, because of an unrelated Rubocop offense. I'll happily rebase this commit on #218, but that PR looks like it's incomplete).~~