### PR TITLE
Small code cleanups

### DIFF
--- a/lib/happymapper.rb
+++ b/lib/happymapper.rb
@@ -549,7 +549,9 @@ module HappyMapper
     # in a recursive call from the parent doc.  Then append
     # any attributes to the element that were defined above.
     #
-    builder.send("#{tag_from_parent || self.class.tag_name}_", attributes) do |xml|
+
+    tag_name = tag_from_parent || self.class.tag_name
+    builder.send("#{tag_name}_", attributes) do |xml|
       register_namespaces_with_builder(builder)
 
       xml.parent.namespace =

--- a/lib/happymapper/item.rb
+++ b/lib/happymapper/item.rb
@@ -120,11 +120,7 @@ module HappyMapper
 
       custom_parser = create_custom_parser(options[:parser])
 
-      begin
-        custom_parser.call(value)
-      rescue StandardError
-        nil
-      end
+      custom_parser.call(value)
     end
 
     def create_custom_parser(parser)

--- a/lib/happymapper/supported_types.rb
+++ b/lib/happymapper/supported_types.rb
@@ -104,7 +104,7 @@ module HappyMapper
 
     register_type Time do |value|
       Time.parse(value.to_s)
-    rescue StandardError
+    rescue ArgumentError
       Time.at(value.to_i)
     end
 


### PR DESCRIPTION
- Break out complex string interpolation
- Stop silently ignoring custom parser failures
- Limit expected set of exceptions from Time.parse
