### PR TITLE
Pass options into wrapping element

### DIFF
--- a/lib/happymapper/class_methods.rb
+++ b/lib/happymapper/class_methods.rb
@@ -208,7 +208,7 @@ module HappyMapper
     # @param [String] name the name of the element that is just a place holder
     # @param [Proc] blk the element definitions inside the place holder tag
     #
-    def wrap(name, &blk)
+    def wrap(name, options = {}, &blk)
       # Get an anonymous HappyMapper that has 'name' as its tag and defined
       # in '&blk'.  Then save that to a class instance variable for later use
       wrapper = AnonymousWrapperClassFactory.get(name, &blk)
@@ -236,7 +236,7 @@ module HappyMapper
         RUBY
       end
 
-      has_one name, wrapper
+      has_one name, wrapper, options
     end
 
     # The callback defined through {.with_nokogiri_config}.

--- a/spec/features/wrap_spec.rb
+++ b/spec/features/wrap_spec.rb
@@ -21,6 +21,15 @@ module Wrap
     end
     element :number, Integer
   end
+
+  class Root2
+    include HappyMapper
+    tag "root"
+
+    wrap "tag_wrapper", tag: "mywraptag" do
+      element :description, String
+    end
+  end
 end
 
 RSpec.describe "wrap which allows you to specify a wrapper element" do
@@ -39,6 +48,14 @@ RSpec.describe "wrap which allows you to specify a wrapper element" do
           expect(root.subclass.items[1]).to eq "item2"
           expect(root.number).to eq 12_345
         end
+      end
+    end
+
+    context "with alternate wrapper name" do
+      let(:root) { Wrap::Root2.parse fixture_file("wrapper.xml") }
+
+      it "sets the values correctly" do
+        expect(root.description).to eq "some description"
       end
     end
 


### PR DESCRIPTION
I’m working with some XML that has a wrapping element with the same name as what I want for the inner element:

```xml
<foo>
  <bars>
    <bar id="1" />
    <bar id="2" />
    <bar id="3" />
  </bars>
</foo>
```

```ruby
class Foo
  include HappyMappy

  wrap "bars" do
    has_many :bars, Bar # this doesn’t work
  end
end
```

Passing the `options` through lets me give the wrapper a different name:

```ruby
class Foo
  include HappyMappy

  wrap "bars_wrapper", tag: "bars" do
    has_many :bars, Bar
  end
end
```

This allows access to the wrapper via `foo.bars_wrapper` and `foo.bars` directly