### PR TITLE
Update rubocop-rspec and fix new offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,7 +49,7 @@ Naming/PredicateName:
     - 'has_many'
     - 'has_xml_content'
 
-RSpec/FilePath:
+RSpec/SpecFilePathFormat:
   CustomTransform:
     HappyMapper: 'happymapper'
 

--- a/nokogiri-happymapper.gemspec
+++ b/nokogiri-happymapper.gemspec
@@ -39,6 +39,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 1.56"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.2"
   spec.add_development_dependency "rubocop-performance", "~> 1.19"
-  spec.add_development_dependency "rubocop-rspec", "~> 2.23"
+  spec.add_development_dependency "rubocop-rspec", "~> 2.24"
   spec.add_development_dependency "simplecov", "~> 0.22.0"
 end

--- a/spec/features/inheritance_spec.rb
+++ b/spec/features/inheritance_spec.rb
@@ -49,11 +49,11 @@ RSpec.describe "Using inheritance to share elements and attributes" do
 
     context "when parsing xml" do
       it "parses the new overwritten attribut" do
-        expect(overwrite.love).to be == "love"
+        expect(overwrite.love).to eq "love"
       end
 
       it "parses the new overwritten element" do
-        expect(overwrite.genetics).to be == 1001
+        expect(overwrite.genetics).to eq 1001
       end
     end
 
@@ -66,11 +66,11 @@ RSpec.describe "Using inheritance to share elements and attributes" do
       end
 
       it "has only 1 genetics element" do
-        expect(xml.xpath("//genetics").count).to be == 1
+        expect(xml.xpath("//genetics").count).to eq 1
       end
 
       it "has only 1 love attribute" do
-        expect(xml.xpath("@love").text).to be == "love"
+        expect(xml.xpath("@love").text).to eq "love"
       end
     end
   end


### PR DESCRIPTION
- Update minimum rubocop-rspec version to 2.24
- Adjust rubocop configuration for changed cops in rubocop-rspec 1.24.0
- Autocorrect RSpec/Eq
