### PR TITLE
Disable RSpec/FilePath explicitly

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,6 +49,10 @@ Naming/PredicateName:
     - 'has_many'
     - 'has_xml_content'
 
+# Disabled because RSpec/SpecFilePathFormat is automatically enabled as a new cop
+RSpec/FilePath:
+  Enabled: false
+
 RSpec/SpecFilePathFormat:
   CustomTransform:
     HappyMapper: 'happymapper'


### PR DESCRIPTION
This cop was re-enabled in rubocop-rspec, but the configuration for this project was already moved to RSpec/SpecFilePathFormat, so use that one instead.
