### PR TITLE
fix namespace prefix collisions

### DIFF
--- a/lib/happymapper/class_methods.rb
+++ b/lib/happymapper/class_methods.rb
@@ -289,7 +289,7 @@ module HappyMapper
         node = xml.root
 
         # merge any namespaces found on the xml node into the namespace hash
-        namespaces = namespaces.merge(xml.collect_namespaces)
+        namespaces = namespaces.merge(xml.collect_namespaces).merge(node.namespaces)
 
         # if the node name is equal to the tag name then the we are parsing the
         # root element and that is important to record so that we can apply


### PR DESCRIPTION
Nokogiri notes a possible problem with this because `collect_namespaces` flattens down to a hash by prefix. My fix merges the root node's view of namespaces after collecting everything, so the root node can still be found.