### PR TITLE
Replace soft-deprecated runtime dependency specification

### DIFF
--- a/nokogiri-happymapper.gemspec
+++ b/nokogiri-happymapper.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.extra_rdoc_files = ["README.md", "CHANGELOG.md", "License"]
 
-  spec.add_runtime_dependency "nokogiri", "~> 1.5"
+  spec.add_dependency "nokogiri", "~> 1.5"
 
   spec.add_development_dependency "pry", "~> 0.14.0"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
Using add_runtime_dependency is soft-deprecated and now flagged by RuboCop.
