### PR TITLE
Update rubocop dependencies and configuration and fix new offense

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_mode:
   merge:
     - Exclude
 
-require:
+plugins:
   - rubocop-packaging
   - rubocop-performance
   - rubocop-rspec

--- a/bin/bundle
+++ b/bin/bundle
@@ -60,7 +60,7 @@ m = Module.new do
     return unless File.file?(lockfile)
 
     lockfile_contents = File.read(lockfile)
-    unless lockfile_contents =~ \
+    unless lockfile_contents =~
            /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/o
       return
     end

--- a/nokogiri-happymapper.gemspec
+++ b/nokogiri-happymapper.gemspec
@@ -35,9 +35,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop", "~> 1.56"
-  spec.add_development_dependency "rubocop-packaging", "~> 0.5.2"
-  spec.add_development_dependency "rubocop-performance", "~> 1.19"
-  spec.add_development_dependency "rubocop-rspec", "~> 3.0"
+  spec.add_development_dependency "rubocop", "~> 1.75"
+  spec.add_development_dependency "rubocop-packaging", "~> 0.6.0"
+  spec.add_development_dependency "rubocop-performance", "~> 1.25"
+  spec.add_development_dependency "rubocop-rspec", "~> 3.5"
   spec.add_development_dependency "simplecov", "~> 0.22.0"
 end


### PR DESCRIPTION
- Update minimum RuboCop dependencies to ensure the plugin system is available
- Use the new rubocop plugins configuration syntax
- Autocorrect Style/RedundantLineContinuation offense
